### PR TITLE
Print assigned TCP socket addresses

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -2,4 +2,4 @@ packages:
   - '.'
 extra-deps:
   - socket-activation-0.1.0.2
-resolver: lts-7.16
+resolver: lts-13.2

--- a/wai-cli.cabal
+++ b/wai-cli.cabal
@@ -44,10 +44,11 @@ library
       , monads-tf
       , stm
       , unix
-      , network
+      , network >= 2.7
       , wai
       , wai-extra
       , ansi-terminal
+      , iproute
     default-language: Haskell2010
     exposed-modules:
         Network.Wai.Cli


### PR DESCRIPTION
As opposed to requested parameters.

Fixes #3. There are other ways to organize the code, I just went for the least intrusive one (though could refactor/adjust it if needed).