### PR TITLE
Allow disabling of unix sockets, so that the project can be built on windows.

### DIFF
--- a/library/Network/Wai/Cli.hs
+++ b/library/Network/Wai/Cli.hs
@@ -81,7 +81,6 @@ instance Options WaiOptions where
 #if defined(WaiCliTLS) && defined(WaiCliUnix)
         , "unix+tls", "activate+tls"
 #endif
-        -- also fastcgi and whatever
         , "fastcgi"
         ]
 

--- a/wai-cli.cabal
+++ b/wai-cli.cabal
@@ -32,22 +32,25 @@ flag fastcgi
     description: Include wai-handler-fastcgi
     default: False
 
+flag unixsockets
+    description: Enable Unix sockets
+    default: True
+
 library
     build-depends:
         base >= 4.8.0.0 && < 5
       , options
       , warp
-      , socket-activation
       , streaming-commons
       , http-types
       , monads-tf
       , stm
-      , unix
       , network >= 2.7
       , wai
       , wai-extra
       , ansi-terminal
       , iproute
+      , signal
     default-language: Haskell2010
     exposed-modules:
         Network.Wai.Cli
@@ -59,3 +62,9 @@ library
     if flag(fastcgi)
         build-depends: wai-handler-fastcgi
         cpp-options: -DWaiCliFastCGI
+    if !os(windows) && flag(unixsockets)
+        cpp-options: -DUnixSockets
+        build-depends:
+            unix
+            , socket-activation
+

--- a/wai-cli.cabal
+++ b/wai-cli.cabal
@@ -50,7 +50,6 @@ library
       , wai-extra
       , ansi-terminal
       , iproute
-      , signal
     default-language: Haskell2010
     exposed-modules:
         Network.Wai.Cli
@@ -63,7 +62,7 @@ library
         build-depends: wai-handler-fastcgi
         cpp-options: -DWaiCliFastCGI
     if !os(windows) && flag(unixsockets)
-        cpp-options: -DUnixSockets
+        cpp-options: -DWaiCliUnix
         build-depends:
             unix
             , socket-activation


### PR DESCRIPTION
I have added a flag to allow unix sockets to be disabled. 
Also, I've added a reference to the `signal` library, because that implements platform-independent signals. 
As a result, I think I might have slightly changed the sigterm handling on unix. - it was using `CatchOnce`, for `sigTERM` but now it's not.

What do you think? With this change I can get magicbane apps compiling on windows, which would be really valuable.

